### PR TITLE
Secure cross-device credential sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,16 @@ GITHUB_SECRET=your_github_client_secret
 # Auth Secret (generate with: openssl rand -base64 32)
 AUTH_SECRET=your_secret_key_here
 
+# Dashboard snapshot encryption keyring. Generate each value independently with
+# `openssl rand -base64 32`; keep prior versions in the JSON object while old
+# snapshots are being migrated on read. This keyring is independent of AUTH_SECRET.
+DASHBOARD_STATE_ENCRYPTION_KEY_VERSION=v1
+DASHBOARD_STATE_ENCRYPTION_KEYS={"v1":"your_independent_32_byte_encryption_secret"}
+
+# Optional fallback for enc:v1 snapshots if AUTH_SECRET is rotated before every
+# record has migrated. Keep the old AUTH_SECRET here until migration is complete.
+# DASHBOARD_STATE_LEGACY_AUTH_SECRETS=["previous_auth_secret"]
+
 # Base URL (for local dev)
 AUTH_TRUST_HOST=true
 

--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,8 @@ GITHUB_SECRET=your_github_client_secret
 AUTH_SECRET=your_secret_key_here
 
 # Dashboard snapshot encryption keyring. Generate each value independently with
-# `openssl rand -base64 32`; keep prior versions in the JSON object while old
-# snapshots are being migrated on read. This keyring is independent of AUTH_SECRET.
+# `openssl rand -base64 32`; keep prior versions in the JSON object until old
+# snapshots are next written or deliberately migrated. This is independent of AUTH_SECRET.
 DASHBOARD_STATE_ENCRYPTION_KEY_VERSION=v1
 DASHBOARD_STATE_ENCRYPTION_KEYS={"v1":"your_independent_32_byte_encryption_secret"}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run check
+      - run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,4 +20,5 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run check
+      - run: npm test
       - run: npm run build

--- a/README.md
+++ b/README.md
@@ -125,6 +125,17 @@ This app is configured to deploy to Cloudflare Pages:
    - `GITHUB_SECRET`
    - `AUTH_SECRET`
    - `AUTH_TRUST_HOST=true`
+   - `DASHBOARD_STATE_ENCRYPTION_KEY_VERSION` (for example, `v1`)
+   - `DASHBOARD_STATE_ENCRYPTION_KEYS` (a JSON keyring such as
+     `{"v1":"<independently generated secret>"}`)
+
+Dashboard snapshots use the active version in `DASHBOARD_STATE_ENCRYPTION_KEYS`,
+not `AUTH_SECRET`. To rotate encryption keys, add the new version without
+removing the old one, change `DASHBOARD_STATE_ENCRYPTION_KEY_VERSION`, deploy,
+and retain both versions while snapshots are re-encrypted on read. Existing
+unversioned `enc:v1` snapshots fall back to the current `AUTH_SECRET`. If that
+secret must rotate before migration finishes, temporarily set
+`DASHBOARD_STATE_LEGACY_AUTH_SECRETS` to a JSON array containing the old value.
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -132,9 +132,12 @@ This app is configured to deploy to Cloudflare Pages:
 Dashboard snapshots use the active version in `DASHBOARD_STATE_ENCRYPTION_KEYS`,
 not `AUTH_SECRET`. To rotate encryption keys, add the new version without
 removing the old one, change `DASHBOARD_STATE_ENCRYPTION_KEY_VERSION`, deploy,
-and retain both versions while snapshots are re-encrypted on read. Existing
-unversioned `enc:v1` snapshots fall back to the current `AUTH_SECRET`. If that
-secret must rotate before migration finishes, temporarily set
+and retain both versions until old-version snapshots are next written or
+deliberately migrated. Legacy plaintext and unversioned `enc:v1` snapshots move
+to a separately keyed encrypted migration record on read, so that migration
+cannot overwrite a concurrent normal write. Existing `enc:v1` snapshots fall
+back to the current `AUTH_SECRET`. If that secret must rotate before migration
+finishes, temporarily set
 `DASHBOARD_STATE_LEGACY_AUTH_SECRETS` to a JSON array containing the old value.
 
 ## Tech Stack

--- a/README.md
+++ b/README.md
@@ -135,9 +135,11 @@ removing the old one, change `DASHBOARD_STATE_ENCRYPTION_KEY_VERSION`, deploy,
 and retain both versions until old-version snapshots are next written or
 deliberately migrated. Legacy plaintext and unversioned `enc:v1` snapshots move
 to a separately keyed encrypted migration record on read, so that migration
-cannot overwrite a concurrent normal write. Existing `enc:v1` snapshots fall
-back to the current `AUTH_SECRET`. If that secret must rotate before migration
-finishes, temporarily set
+cannot overwrite a concurrent normal write. Replacement and fallback values
+coexist for a bounded propagation window because Workers KV does not make
+cross-key writes and deletes visible atomically; the legacy value then expires.
+Existing `enc:v1` snapshots fall back to the current `AUTH_SECRET`. If that
+secret must rotate before migration finishes, temporarily set
 `DASHBOARD_STATE_LEGACY_AUTH_SECRETS` to a JSON array containing the old value.
 
 ## Tech Stack

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,20 +40,49 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@auth/sveltekit": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@auth/sveltekit/-/sveltekit-1.11.0.tgz",
-      "integrity": "sha512-5LY3IP0rWLlTmHaaLNP/cMU0rzPapKAWTJGeZx37mZf8d+3KH1ClQCze0JCJ5mbTm8WTAXQBsNTeq0u1H8N0KA==",
+    "node_modules/@auth/core": {
+      "version": "0.41.3",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.3.tgz",
+      "integrity": "sha512-sJ3JMHHkXMD3aOjopv7mOBTO1Ocw4b0fAEXJBz6k7YHLpYQI6C40jCUPc5fNvUKxXRXNE1/sRISA15UrwWJBTw==",
       "license": "ISC",
       "dependencies": {
-        "@auth/core": "0.41.0",
+        "@panva/hkdf": "^1.2.1",
+        "jose": "^6.0.6",
+        "oauth4webapi": "^3.3.0",
+        "preact": "10.24.3",
+        "preact-render-to-string": "6.5.11"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^7.0.7 || ^8.0.5"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@auth/sveltekit": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@auth/sveltekit/-/sveltekit-1.11.3.tgz",
+      "integrity": "sha512-nfI/CFHD9hpJG4W+u+xtMrw9XSrA1k6kbgbGc9PvbiEf67oPMuzLAvLDj6/3yd98kFz+51Rq04JLBckKp8T5Kg==",
+      "license": "ISC",
+      "dependencies": {
+        "@auth/core": "0.41.3",
         "set-cookie-parser": "^2.7.0"
       },
       "peerDependencies": {
         "@simplewebauthn/browser": "^9.0.1",
         "@simplewebauthn/server": "^9.0.3",
         "@sveltejs/kit": "^1.0.0 || ^2.0.0",
-        "nodemailer": "^6.6.5",
+        "nodemailer": "^7.0.7 || ^8.0.5",
         "svelte": "^3.54.0 || ^4.0.0 || ^5.0.0-0"
       },
       "peerDependenciesMeta": {
@@ -66,44 +95,6 @@
         "nodemailer": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@auth/sveltekit/node_modules/@auth/core": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.0.tgz",
-      "integrity": "sha512-Wd7mHPQ/8zy6Qj7f4T46vg3aoor8fskJm6g2Zyj064oQ3+p0xNZXAV60ww0hY+MbTesfu29kK14Zk5d5JTazXQ==",
-      "license": "ISC",
-      "dependencies": {
-        "@panva/hkdf": "^1.2.1",
-        "jose": "^6.0.6",
-        "oauth4webapi": "^3.3.0",
-        "preact": "10.24.3",
-        "preact-render-to-string": "6.5.11"
-      },
-      "peerDependencies": {
-        "@simplewebauthn/browser": "^9.0.1",
-        "@simplewebauthn/server": "^9.0.2",
-        "nodemailer": "^6.8.0"
-      },
-      "peerDependenciesMeta": {
-        "@simplewebauthn/browser": {
-          "optional": true
-        },
-        "@simplewebauthn/server": {
-          "optional": true
-        },
-        "nodemailer": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@auth/sveltekit/node_modules/jose": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.0.tgz",
-      "integrity": "sha512-TTQJyoEoKcC1lscpVDCSsVgYzUDg/0Bt3WE//WiTPK6uOCQC2KZS4MpugbMWt/zyjkopgZoXhZuCi00gLudfUA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -1377,6 +1368,25 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1431,9 +1441,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.5.tgz",
-      "integrity": "sha512-8c1vW4ocv3UOMp9K+gToY5zL2XiiVw3k7f1ksf4yO1FlDFQ1C2u72iACFnSOceJFsWskc2WZNqeRhFRPzv+wtQ==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
       "cpu": [
         "arm"
       ],
@@ -1444,9 +1454,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.5.tgz",
-      "integrity": "sha512-mQGfsIEFcu21mvqkEKKu2dYmtuSZOBMmAl5CFlPGLY94Vlcm+zWApK7F/eocsNzp8tKmbeBP8yXyAbx0XHsFNA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
       "cpu": [
         "arm64"
       ],
@@ -1457,9 +1467,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.5.tgz",
-      "integrity": "sha512-takF3CR71mCAGA+v794QUZ0b6ZSrgJkArC+gUiG6LB6TQty9T0Mqh3m2ImRBOxS2IeYBo4lKWIieSvnEk2OQWA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
       "cpu": [
         "arm64"
       ],
@@ -1470,9 +1480,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.5.tgz",
-      "integrity": "sha512-W901Pla8Ya95WpxDn//VF9K9u2JbocwV/v75TE0YIHNTbhqUTv9w4VuQ9MaWlNOkkEfFwkdNhXgcLqPSmHy0fA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
       "cpu": [
         "x64"
       ],
@@ -1483,9 +1493,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.5.tgz",
-      "integrity": "sha512-QofO7i7JycsYOWxe0GFqhLmF6l1TqBswJMvICnRUjqCx8b47MTo46W8AoeQwiokAx3zVryVnxtBMcGcnX12LvA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
       "cpu": [
         "arm64"
       ],
@@ -1496,9 +1506,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.5.tgz",
-      "integrity": "sha512-jr21b/99ew8ujZubPo9skbrItHEIE50WdV86cdSoRkKtmWa+DDr6fu2c/xyRT0F/WazZpam6kk7IHBerSL7LDQ==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
       "cpu": [
         "x64"
       ],
@@ -1509,11 +1519,14 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.5.tgz",
-      "integrity": "sha512-PsNAbcyv9CcecAUagQefwX8fQn9LQ4nZkpDboBOttmyffnInRy8R8dSg6hxxl2Re5QhHBf6FYIDhIj5v982ATQ==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
       "cpu": [
         "arm"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1522,11 +1535,14 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.5.tgz",
-      "integrity": "sha512-Fw4tysRutyQc/wwkmcyoqFtJhh0u31K+Q6jYjeicsGJJ7bbEq8LwPWV/w0cnzOqR2m694/Af6hpFayLJZkG2VQ==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
       "cpu": [
         "arm"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1535,11 +1551,14 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.5.tgz",
-      "integrity": "sha512-a+3wVnAYdQClOTlyapKmyI6BLPAFYs0JM8HRpgYZQO02rMR09ZcV9LbQB+NL6sljzG38869YqThrRnfPMCDtZg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1548,11 +1567,14 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.5.tgz",
-      "integrity": "sha512-AvttBOMwO9Pcuuf7m9PkC1PUIKsfaAJ4AYhy944qeTJgQOqJYJ9oVl2nYgY7Rk0mkbsuOpCAYSs6wLYB2Xiw0Q==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1561,11 +1583,30 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.5.tgz",
-      "integrity": "sha512-DkDk8pmXQV2wVrF6oq5tONK6UHLz/XcEVow4JTTerdeV1uqPeHxwcg7aFsfnSm9L+OO8WJsWotKM2JJPMWrQtA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
       "cpu": [
         "loong64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1574,11 +1615,30 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.5.tgz",
-      "integrity": "sha512-W/b9ZN/U9+hPQVvlGwjzi+Wy4xdoH2I8EjaCkMvzpI7wJUs8sWJ03Rq96jRnHkSrcHTpQe8h5Tg3ZzUPGauvAw==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
       "cpu": [
         "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1587,11 +1647,14 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.5.tgz",
-      "integrity": "sha512-sjQLr9BW7R/ZiXnQiWPkErNfLMkkWIoCz7YMn27HldKsADEKa5WYdobaa1hmN6slu9oWQbB6/jFpJ+P2IkVrmw==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
       "cpu": [
         "riscv64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1600,11 +1663,14 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.5.tgz",
-      "integrity": "sha512-hq3jU/kGyjXWTvAh2awn8oHroCbrPm8JqM7RUpKjalIRWWXE01CQOf/tUNWNHjmbMHg/hmNCwc/Pz3k1T/j/Lg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
       "cpu": [
         "riscv64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1613,11 +1679,14 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.5.tgz",
-      "integrity": "sha512-gn8kHOrku8D4NGHMK1Y7NA7INQTRdVOntt1OCYypZPRt6skGbddska44K8iocdpxHTMMNui5oH4elPH4QOLrFQ==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
       "cpu": [
         "s390x"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1626,11 +1695,14 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.5.tgz",
-      "integrity": "sha512-hXGLYpdhiNElzN770+H2nlx+jRog8TyynpTVzdlc6bndktjKWyZyiCsuDAlpd+j+W+WNqfcyAWz9HxxIGfZm1Q==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1639,11 +1711,14 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.5.tgz",
-      "integrity": "sha512-arCGIcuNKjBoKAXD+y7XomR9gY6Mw7HnFBv5Rw7wQRvwYLR7gBAgV7Mb2QTyjXfTveBNFAtPt46/36vV9STLNg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1651,10 +1726,23 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.5.tgz",
-      "integrity": "sha512-QoFqB6+/9Rly/RiPjaomPLmR/13cgkIGfA40LHly9zcH1S0bN2HVFYk3a1eAyHQyjs3ZJYlXvIGtcCs5tko9Cw==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
       "cpu": [
         "arm64"
       ],
@@ -1665,9 +1753,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.5.tgz",
-      "integrity": "sha512-w0cDWVR6MlTstla1cIfOGyl8+qb93FlAVutcor14Gf5Md5ap5ySfQ7R9S/NjNaMLSFdUnKGEasmVnu3lCMqB7w==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
       "cpu": [
         "arm64"
       ],
@@ -1678,9 +1766,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.5.tgz",
-      "integrity": "sha512-Aufdpzp7DpOTULJCuvzqcItSGDH73pF3ko/f+ckJhxQyHtp67rHw3HMNxoIdDMUITJESNE6a8uh4Lo4SLouOUg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
       "cpu": [
         "ia32"
       ],
@@ -1691,9 +1779,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.5.tgz",
-      "integrity": "sha512-UGBUGPFp1vkj6p8wCRraqNhqwX/4kNQPS57BCFc8wYh0g94iVIW33wJtQAx3G7vrjjNtRaxiMUylM0ktp/TRSQ==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
       "cpu": [
         "x64"
       ],
@@ -1704,9 +1792,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.5.tgz",
-      "integrity": "sha512-TAcgQh2sSkykPRWLrdyy2AiceMckNf5loITqXxFI5VuQjS5tSuw3WlwdN8qv8vzjLAUTvYaH/mVjSFpbkFbpTg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
       "cpu": [
         "x64"
       ],
@@ -1723,9 +1811,9 @@
       "license": "MIT"
     },
     "node_modules/@sveltejs/acorn-typescript": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.6.tgz",
-      "integrity": "sha512-4awhxtMh4cx9blePWl10HRHj8Iivtqj+2QdDCSMDzxG+XKa9+VCNupQuCuvzEhYPzZSrX+0gC+0lHA/0fFKKQQ==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.12.tgz",
+      "integrity": "sha512-J1jNYG23QWd67UfrQSFHtjhV37r9mVi0gdc12A3MWPldOjRK35Xk+um+qACPVjgw3AleiqoyEAhok8Wm3q46NA==",
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8.9.0"
@@ -1748,23 +1836,22 @@
       }
     },
     "node_modules/@sveltejs/kit": {
-      "version": "2.47.3",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.47.3.tgz",
-      "integrity": "sha512-zN2yzBc2dIES2BSzLhNP2weYhwB77kgM/oAktICZVmmljyEmPZrlUwr14jjdK9/eDu7WdAuf6gTdYIJLTcN3Fw==",
+      "version": "2.70.2",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.70.2.tgz",
+      "integrity": "sha512-RzRoRpuR2KXqc5yMO0akQHDZeT4AslOlznGITURsqHaVbtyYP4Wn3eE3gxj9JcDyNYO0crkxhdwFHc+2vkVm6w==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
-        "@sveltejs/acorn-typescript": "^1.0.5",
+        "@sveltejs/acorn-typescript": "^1.0.9",
         "@types/cookie": "^0.6.0",
-        "acorn": "^8.14.1",
+        "acorn": "^8.16.0",
         "cookie": "^0.6.0",
-        "devalue": "^5.3.2",
+        "devalue": "^5.8.1",
         "esm-env": "^1.2.2",
         "kleur": "^4.1.5",
         "magic-string": "^0.30.5",
         "mrmime": "^2.0.0",
-        "sade": "^1.8.1",
-        "set-cookie-parser": "^2.6.0",
+        "set-cookie-parser": "^3.0.0",
         "sirv": "^3.0.0"
       },
       "bin": {
@@ -1775,15 +1862,25 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0",
-        "@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0",
+        "@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0",
         "svelte": "^4.0.0 || ^5.0.0-next.0",
-        "vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0"
+        "typescript": "^5.3.3 || ^6.0.0",
+        "vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@opentelemetry/api": {
           "optional": true
+        },
+        "typescript": {
+          "optional": true
         }
       }
+    },
+    "node_modules/@sveltejs/kit/node_modules/set-cookie-parser": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.2.tgz",
+      "integrity": "sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==",
+      "license": "MIT"
     },
     "node_modules/@sveltejs/vite-plugin-svelte": {
       "version": "3.1.2",
@@ -1831,9 +1928,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
     },
     "node_modules/@types/google.maps": {
@@ -2125,9 +2222,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -2558,9 +2655,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.4.2.tgz",
-      "integrity": "sha512-MwPZTKEPK2k8Qgfmqrd48ZKVvzSQjgW0lXLxiIBA8dQjtf/6mw6pggHNLcyDKyf+fI6eXxlQwPsfaCMTU5U+Bw==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.9.0.tgz",
+      "integrity": "sha512-RWrqdArjvPbsATEhOPUo6Wndc/iWnkWKlhIrdlF3zMMYo/c3CVtoaVAyLtWxz5h8nSlkHzxnzV2uLydPXmtF+A==",
       "license": "MIT"
     },
     "node_modules/es6-promise": {
@@ -3231,6 +3328,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/jose": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -3488,6 +3594,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
       "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -3520,9 +3627,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -3555,9 +3662,9 @@
       }
     },
     "node_modules/oauth4webapi": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.2.tgz",
-      "integrity": "sha512-FzZZ+bht5X0FKe7Mwz3DAVAmlH1BV5blSak/lHMBKz0/EBMhX6B10GlQYI51+oRp8ObJaX0g6pXrAxZh5s8rjw==",
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -3721,9 +3828,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -3740,7 +3847,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3963,12 +4070,12 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.5.tgz",
-      "integrity": "sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@types/estree": "1.0.9"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -3978,28 +4085,32 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.52.5",
-        "@rollup/rollup-android-arm64": "4.52.5",
-        "@rollup/rollup-darwin-arm64": "4.52.5",
-        "@rollup/rollup-darwin-x64": "4.52.5",
-        "@rollup/rollup-freebsd-arm64": "4.52.5",
-        "@rollup/rollup-freebsd-x64": "4.52.5",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.52.5",
-        "@rollup/rollup-linux-arm-musleabihf": "4.52.5",
-        "@rollup/rollup-linux-arm64-gnu": "4.52.5",
-        "@rollup/rollup-linux-arm64-musl": "4.52.5",
-        "@rollup/rollup-linux-loong64-gnu": "4.52.5",
-        "@rollup/rollup-linux-ppc64-gnu": "4.52.5",
-        "@rollup/rollup-linux-riscv64-gnu": "4.52.5",
-        "@rollup/rollup-linux-riscv64-musl": "4.52.5",
-        "@rollup/rollup-linux-s390x-gnu": "4.52.5",
-        "@rollup/rollup-linux-x64-gnu": "4.52.5",
-        "@rollup/rollup-linux-x64-musl": "4.52.5",
-        "@rollup/rollup-openharmony-arm64": "4.52.5",
-        "@rollup/rollup-win32-arm64-msvc": "4.52.5",
-        "@rollup/rollup-win32-ia32-msvc": "4.52.5",
-        "@rollup/rollup-win32-x64-gnu": "4.52.5",
-        "@rollup/rollup-win32-x64-msvc": "4.52.5",
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
         "fsevents": "~2.3.2"
       }
     },
@@ -4094,6 +4205,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
       "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mri": "^1.1.0"
@@ -4589,7 +4701,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
         "tslib": "^2.6.0",
         "typescript": "^5.0.0",
         "typescript-eslint": "^8.0.0",
-        "vite": "^5.0.0"
+        "vite": "^5.0.0",
+        "vitest": "^2.1.9"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2221,6 +2222,133 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
@@ -2328,6 +2456,16 @@
         "printable-characters": "^1.0.42"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -2399,6 +2537,16 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2407,6 +2555,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -2424,6 +2589,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -2608,6 +2783,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2658,6 +2843,13 @@
       "version": "5.9.0",
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.9.0.tgz",
       "integrity": "sha512-RWrqdArjvPbsATEhOPUo6Wndc/iWnkWKlhIrdlF3zMMYo/c3CVtoaVAyLtWxz5h8nSlkHzxnzV2uLydPXmtF+A==",
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/es6-promise": {
@@ -2953,6 +3145,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/exsolve": {
@@ -3450,6 +3652,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/magic-string": {
       "version": "0.30.19",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
@@ -3796,6 +4005,16 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/periscopic": {
       "version": "3.1.0",
@@ -4311,6 +4530,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/simple-swizzle": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
@@ -4382,6 +4608,13 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stacktracey": {
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/stacktracey/-/stacktracey-2.1.8.tgz",
@@ -4393,6 +4626,13 @@
         "as-table": "^1.0.36",
         "get-source": "^2.0.12"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stoppable": {
       "version": "1.1.0",
@@ -4642,6 +4882,50 @@
         }
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4854,6 +5138,36 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -5275,6 +5589,79 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5289,6 +5676,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview --host 0.0.0.0 --port 4200",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "vitest run"
   },
   "devDependencies": {
     "@sveltejs/adapter-cloudflare": "^4.0.0",
@@ -25,7 +26,8 @@
     "tslib": "^2.6.0",
     "typescript": "^5.0.0",
     "typescript-eslint": "^8.0.0",
-    "vite": "^5.0.0"
+    "vite": "^5.0.0",
+    "vitest": "^2.1.9"
   },
   "type": "module",
   "dependencies": {

--- a/src/lib/server/stateEncryption.test.ts
+++ b/src/lib/server/stateEncryption.test.ts
@@ -1,29 +1,105 @@
 import { describe, expect, it } from 'vitest';
-import { decryptState, encryptState } from './stateEncryption';
+import {
+	decryptState,
+	encryptState,
+	parseStateEncryptionConfig,
+	type StateEncryptionConfig
+} from './stateEncryption';
+
+const ownerKey = 'dashboard-state:alice';
+const config: StateEncryptionConfig = {
+	activeVersion: '2026-08',
+	keys: { '2026-08': 'test-dashboard-encryption-secret-0001' },
+	legacySecrets: ['test-auth-secret']
+};
+
+async function encryptLegacy(plaintext: string, secret: string): Promise<string> {
+	const encoder = new TextEncoder();
+	const digest = await crypto.subtle.digest('SHA-256', encoder.encode(secret));
+	const key = await crypto.subtle.importKey('raw', digest, 'AES-GCM', false, ['encrypt']);
+	const iv = crypto.getRandomValues(new Uint8Array(12));
+	const ciphertext = new Uint8Array(await crypto.subtle.encrypt(
+		{ name: 'AES-GCM', iv },
+		key,
+		encoder.encode(plaintext)
+	));
+	const base64 = (bytes: Uint8Array) => btoa(String.fromCharCode(...bytes));
+	return `enc:v1:${base64(iv)}:${base64(ciphertext)}`;
+}
 
 describe('dashboard state encryption', () => {
 	it('round-trips credentials without exposing them in stored bytes', async () => {
 		const plaintext = JSON.stringify({ token: 'sensitive-api-token' });
-		const encrypted = await encryptState(plaintext, 'test-auth-secret');
+		const encrypted = await encryptState(plaintext, config, ownerKey);
 
-		expect(encrypted).toMatch(/^enc:v1:/);
+		expect(encrypted).toMatch(/^enc:v2:2026-08:/);
 		expect(encrypted).not.toContain('sensitive-api-token');
-		expect(await decryptState(encrypted, 'test-auth-secret')).toBe(plaintext);
+		expect(await decryptState(encrypted, config, ownerKey)).toEqual({
+			plaintext,
+			needsMigration: false
+		});
 	});
 
-	it('reads legacy plaintext records for migration', async () => {
-		expect(await decryptState('{"legacy":true}', 'test-auth-secret')).toBe('{"legacy":true}');
+	it('marks legacy plaintext records for migration', async () => {
+		expect(await decryptState('{"legacy":true}', config, ownerKey)).toEqual({
+			plaintext: '{"legacy":true}',
+			needsMigration: true
+		});
+	});
+
+	it('decrypts pre-keyring ciphertext with a retained AUTH_SECRET fallback', async () => {
+		const encrypted = await encryptLegacy('legacy ciphertext', 'test-auth-secret');
+
+		expect(await decryptState(encrypted, config, ownerKey)).toEqual({
+			plaintext: 'legacy ciphertext',
+			needsMigration: true
+		});
 	});
 
 	it('supports dashboard snapshots larger than the function argument limit', async () => {
 		const plaintext = 'x'.repeat(200_000);
-		const encrypted = await encryptState(plaintext, 'test-auth-secret');
+		const encrypted = await encryptState(plaintext, config, ownerKey);
 
-		expect(await decryptState(encrypted, 'test-auth-secret')).toBe(plaintext);
+		expect((await decryptState(encrypted, config, ownerKey)).plaintext).toBe(plaintext);
 	});
 
-	it('rejects ciphertext encrypted with another secret', async () => {
-		const encrypted = await encryptState('secret', 'first-secret');
-		await expect(decryptState(encrypted, 'second-secret')).rejects.toThrow();
+	it('rejects ciphertext transplanted to another user', async () => {
+		const encrypted = await encryptState('secret', config, ownerKey);
+		await expect(decryptState(encrypted, config, 'dashboard-state:bob')).rejects.toThrow();
+	});
+
+	it('decrypts an old key version and marks it for re-encryption', async () => {
+		const oldConfig: StateEncryptionConfig = {
+			activeVersion: '2026-07',
+			keys: { '2026-07': 'test-dashboard-encryption-secret-0000' },
+			legacySecrets: []
+		};
+		const encrypted = await encryptState('secret', oldConfig, ownerKey);
+		const rotatedConfig: StateEncryptionConfig = {
+			activeVersion: '2026-08',
+			keys: { ...oldConfig.keys, ...config.keys },
+			legacySecrets: []
+		};
+
+		expect(await decryptState(encrypted, rotatedConfig, ownerKey)).toEqual({
+			plaintext: 'secret',
+			needsMigration: true
+		});
+	});
+
+	it('uses AUTH_SECRET only as a fallback for unversioned legacy ciphertext', () => {
+		const parsed = parseStateEncryptionConfig({
+			AUTH_SECRET: 'legacy-auth-secret',
+			DASHBOARD_STATE_ENCRYPTION_KEY_VERSION: 'v2',
+			DASHBOARD_STATE_ENCRYPTION_KEYS: JSON.stringify({
+				v2: 'test-dashboard-encryption-secret-0001'
+			})
+		});
+
+		expect(parsed).toMatchObject({
+			activeVersion: 'v2',
+			legacySecrets: ['legacy-auth-secret']
+		});
+		expect(parsed?.keys.v2).toBe('test-dashboard-encryption-secret-0001');
 	});
 });

--- a/src/lib/server/stateEncryption.test.ts
+++ b/src/lib/server/stateEncryption.test.ts
@@ -102,4 +102,19 @@ describe('dashboard state encryption', () => {
 		});
 		expect(parsed?.keys.v2).toBe('test-dashboard-encryption-secret-0001');
 	});
+
+	it('rejects an inherited property name when the active key is absent', () => {
+		expect(() => parseStateEncryptionConfig({
+			DASHBOARD_STATE_ENCRYPTION_KEY_VERSION: 'constructor',
+			DASHBOARD_STATE_ENCRYPTION_KEYS: JSON.stringify({
+				v2: 'test-dashboard-encryption-secret-0001'
+			})
+		})).toThrow('Active dashboard encryption key is not configured');
+	});
+
+	it('does not decrypt an inherited ciphertext key version', async () => {
+		await expect(
+			decryptState('enc:v2:constructor:AA==:AA==', config, ownerKey)
+		).rejects.toThrow('Dashboard encryption key constructor is not configured');
+	});
 });

--- a/src/lib/server/stateEncryption.test.ts
+++ b/src/lib/server/stateEncryption.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { decryptState, encryptState } from './stateEncryption';
+
+describe('dashboard state encryption', () => {
+	it('round-trips credentials without exposing them in stored bytes', async () => {
+		const plaintext = JSON.stringify({ token: 'sensitive-api-token' });
+		const encrypted = await encryptState(plaintext, 'test-auth-secret');
+
+		expect(encrypted).toMatch(/^enc:v1:/);
+		expect(encrypted).not.toContain('sensitive-api-token');
+		expect(await decryptState(encrypted, 'test-auth-secret')).toBe(plaintext);
+	});
+
+	it('reads legacy plaintext records for migration', async () => {
+		expect(await decryptState('{"legacy":true}', 'test-auth-secret')).toBe('{"legacy":true}');
+	});
+
+	it('supports dashboard snapshots larger than the function argument limit', async () => {
+		const plaintext = 'x'.repeat(200_000);
+		const encrypted = await encryptState(plaintext, 'test-auth-secret');
+
+		expect(await decryptState(encrypted, 'test-auth-secret')).toBe(plaintext);
+	});
+
+	it('rejects ciphertext encrypted with another secret', async () => {
+		const encrypted = await encryptState('secret', 'first-secret');
+		await expect(decryptState(encrypted, 'second-secret')).rejects.toThrow();
+	});
+});

--- a/src/lib/server/stateEncryption.ts
+++ b/src/lib/server/stateEncryption.ts
@@ -43,7 +43,7 @@ function parseKeys(raw: string): Record<string, string> {
 		throw new Error('DASHBOARD_STATE_ENCRYPTION_KEYS must be a JSON object');
 	}
 
-	const keys: Record<string, string> = {};
+	const keys = Object.create(null) as Record<string, string>;
 	for (const [version, value] of Object.entries(parsed)) {
 		if (!VERSION_PATTERN.test(version) || typeof value !== 'string' || value.trim().length < 32) {
 			throw new Error('Dashboard encryption key versions and values are invalid');
@@ -51,6 +51,12 @@ function parseKeys(raw: string): Record<string, string> {
 		keys[version] = value.trim();
 	}
 	return keys;
+}
+
+function configuredKey(keys: Readonly<Record<string, string>>, version: string): string | undefined {
+	if (!Object.hasOwn(keys, version)) return undefined;
+	const value = keys[version];
+	return typeof value === 'string' ? value : undefined;
 }
 
 function parseLegacySecrets(raw: string | undefined): string[] {
@@ -71,7 +77,9 @@ export function parseStateEncryptionConfig(
 	if (!VERSION_PATTERN.test(activeVersion)) throw new Error('Invalid active encryption key version');
 
 	const keys = parseKeys(rawKeys);
-	if (!keys[activeVersion]) throw new Error('Active dashboard encryption key is not configured');
+	if (!configuredKey(keys, activeVersion)) {
+		throw new Error('Active dashboard encryption key is not configured');
+	}
 
 	const legacySecrets = parseLegacySecrets(environment.DASHBOARD_STATE_LEGACY_AUTH_SECRETS);
 	const currentAuthSecret = environment.AUTH_SECRET?.trim();
@@ -90,7 +98,7 @@ export async function encryptState(
 	ownerKey: string
 ): Promise<string> {
 	const version = config.activeVersion;
-	const secret = config.keys[version];
+	const secret = configuredKey(config.keys, version);
 	if (!secret) throw new Error(`Dashboard encryption key ${version} is not configured`);
 
 	const iv = crypto.getRandomValues(new Uint8Array(12));
@@ -139,7 +147,7 @@ export async function decryptState(
 		throw new Error('Invalid encrypted dashboard state');
 	}
 	const [version, iv, ciphertext] = parts;
-	const secret = config.keys[version];
+	const secret = configuredKey(config.keys, version);
 	if (!secret) throw new Error(`Dashboard encryption key ${version} is not configured`);
 
 	const plaintext = await crypto.subtle.decrypt(

--- a/src/lib/server/stateEncryption.ts
+++ b/src/lib/server/stateEncryption.ts
@@ -1,0 +1,41 @@
+const PREFIX = 'enc:v1:';
+
+function encode(bytes: Uint8Array): string {
+	let binary = '';
+	for (let offset = 0; offset < bytes.length; offset += 0x8000) {
+		binary += String.fromCharCode(...bytes.subarray(offset, offset + 0x8000));
+	}
+	return btoa(binary);
+}
+
+function decode(value: string): ArrayBuffer {
+	return Uint8Array.from(atob(value), (char) => char.charCodeAt(0)).buffer as ArrayBuffer;
+}
+
+async function deriveKey(secret: string): Promise<CryptoKey> {
+	const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(secret));
+	return crypto.subtle.importKey('raw', digest, 'AES-GCM', false, ['encrypt', 'decrypt']);
+}
+
+export async function encryptState(plaintext: string, secret: string): Promise<string> {
+	const iv = crypto.getRandomValues(new Uint8Array(12));
+	const ciphertext = await crypto.subtle.encrypt(
+		{ name: 'AES-GCM', iv },
+		await deriveKey(secret),
+		new TextEncoder().encode(plaintext)
+	);
+	return `${PREFIX}${encode(iv)}:${encode(new Uint8Array(ciphertext))}`;
+}
+
+export async function decryptState(value: string, secret: string): Promise<string> {
+	// Existing KV records predate encryption and remain readable until next write.
+	if (!value.startsWith(PREFIX)) return value;
+	const [iv, ciphertext] = value.slice(PREFIX.length).split(':');
+	if (!iv || !ciphertext) throw new Error('Invalid encrypted dashboard state');
+	const plaintext = await crypto.subtle.decrypt(
+		{ name: 'AES-GCM', iv: decode(iv) },
+		await deriveKey(secret),
+		decode(ciphertext)
+	);
+	return new TextDecoder().decode(plaintext);
+}

--- a/src/lib/server/stateEncryption.ts
+++ b/src/lib/server/stateEncryption.ts
@@ -1,4 +1,20 @@
-const PREFIX = 'enc:v1:';
+const LEGACY_PREFIX = 'enc:v1:';
+const PREFIX = 'enc:v2:';
+const VERSION_PATTERN = /^[A-Za-z0-9._-]+$/;
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+export interface StateEncryptionConfig {
+	activeVersion: string;
+	keys: Readonly<Record<string, string>>;
+	legacySecrets: readonly string[];
+}
+
+export interface DecryptedState {
+	plaintext: string;
+	needsMigration: boolean;
+}
 
 function encode(bytes: Uint8Array): string {
 	let binary = '';
@@ -13,29 +29,126 @@ function decode(value: string): ArrayBuffer {
 }
 
 async function deriveKey(secret: string): Promise<CryptoKey> {
-	const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(secret));
+	const digest = await crypto.subtle.digest('SHA-256', encoder.encode(secret));
 	return crypto.subtle.importKey('raw', digest, 'AES-GCM', false, ['encrypt', 'decrypt']);
 }
 
-export async function encryptState(plaintext: string, secret: string): Promise<string> {
-	const iv = crypto.getRandomValues(new Uint8Array(12));
-	const ciphertext = await crypto.subtle.encrypt(
-		{ name: 'AES-GCM', iv },
-		await deriveKey(secret),
-		new TextEncoder().encode(plaintext)
-	);
-	return `${PREFIX}${encode(iv)}:${encode(new Uint8Array(ciphertext))}`;
+function additionalData(ownerKey: string, version: string): ArrayBuffer {
+	return encoder.encode(`dashboard-state-encryption:${version}:${ownerKey}`).buffer as ArrayBuffer;
 }
 
-export async function decryptState(value: string, secret: string): Promise<string> {
-	// Existing KV records predate encryption and remain readable until next write.
-	if (!value.startsWith(PREFIX)) return value;
-	const [iv, ciphertext] = value.slice(PREFIX.length).split(':');
-	if (!iv || !ciphertext) throw new Error('Invalid encrypted dashboard state');
+function parseKeys(raw: string): Record<string, string> {
+	const parsed: unknown = JSON.parse(raw);
+	if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+		throw new Error('DASHBOARD_STATE_ENCRYPTION_KEYS must be a JSON object');
+	}
+
+	const keys: Record<string, string> = {};
+	for (const [version, value] of Object.entries(parsed)) {
+		if (!VERSION_PATTERN.test(version) || typeof value !== 'string' || value.trim().length < 32) {
+			throw new Error('Dashboard encryption key versions and values are invalid');
+		}
+		keys[version] = value.trim();
+	}
+	return keys;
+}
+
+function parseLegacySecrets(raw: string | undefined): string[] {
+	if (!raw?.trim()) return [];
+	const parsed: unknown = JSON.parse(raw);
+	if (!Array.isArray(parsed) || parsed.some((value) => typeof value !== 'string' || !value.trim())) {
+		throw new Error('DASHBOARD_STATE_LEGACY_AUTH_SECRETS must be a JSON string array');
+	}
+	return parsed.map((value) => (value as string).trim());
+}
+
+export function parseStateEncryptionConfig(
+	environment: Partial<Record<string, string>>
+): StateEncryptionConfig | null {
+	const activeVersion = environment.DASHBOARD_STATE_ENCRYPTION_KEY_VERSION?.trim();
+	const rawKeys = environment.DASHBOARD_STATE_ENCRYPTION_KEYS?.trim();
+	if (!activeVersion || !rawKeys) return null;
+	if (!VERSION_PATTERN.test(activeVersion)) throw new Error('Invalid active encryption key version');
+
+	const keys = parseKeys(rawKeys);
+	if (!keys[activeVersion]) throw new Error('Active dashboard encryption key is not configured');
+
+	const legacySecrets = parseLegacySecrets(environment.DASHBOARD_STATE_LEGACY_AUTH_SECRETS);
+	const currentAuthSecret = environment.AUTH_SECRET?.trim();
+	if (currentAuthSecret) legacySecrets.unshift(currentAuthSecret);
+
+	return {
+		activeVersion,
+		keys,
+		legacySecrets: [...new Set(legacySecrets)]
+	};
+}
+
+export async function encryptState(
+	plaintext: string,
+	config: StateEncryptionConfig,
+	ownerKey: string
+): Promise<string> {
+	const version = config.activeVersion;
+	const secret = config.keys[version];
+	if (!secret) throw new Error(`Dashboard encryption key ${version} is not configured`);
+
+	const iv = crypto.getRandomValues(new Uint8Array(12));
+	const ciphertext = await crypto.subtle.encrypt(
+		{ name: 'AES-GCM', iv, additionalData: additionalData(ownerKey, version) },
+		await deriveKey(secret),
+		encoder.encode(plaintext)
+	);
+	return `${PREFIX}${version}:${encode(iv)}:${encode(new Uint8Array(ciphertext))}`;
+}
+
+async function decryptLegacy(value: string, secrets: readonly string[]): Promise<string> {
+	const parts = value.slice(LEGACY_PREFIX.length).split(':');
+	if (parts.length !== 2 || !parts[0] || !parts[1]) {
+		throw new Error('Invalid legacy encrypted dashboard state');
+	}
+
+	for (const secret of secrets) {
+		try {
+			const plaintext = await crypto.subtle.decrypt(
+				{ name: 'AES-GCM', iv: decode(parts[0]) },
+				await deriveKey(secret),
+				decode(parts[1])
+			);
+			return decoder.decode(plaintext);
+		} catch {
+			// Try the next explicitly retained legacy authentication secret.
+		}
+	}
+	throw new Error('No configured legacy secret can decrypt dashboard state');
+}
+
+export async function decryptState(
+	value: string,
+	config: StateEncryptionConfig,
+	ownerKey: string
+): Promise<DecryptedState> {
+	if (!value.startsWith('enc:')) return { plaintext: value, needsMigration: true };
+	if (value.startsWith(LEGACY_PREFIX)) {
+		return { plaintext: await decryptLegacy(value, config.legacySecrets), needsMigration: true };
+	}
+	if (!value.startsWith(PREFIX)) throw new Error('Unsupported encrypted dashboard state version');
+
+	const parts = value.slice(PREFIX.length).split(':');
+	if (parts.length !== 3 || !parts[0] || !parts[1] || !parts[2]) {
+		throw new Error('Invalid encrypted dashboard state');
+	}
+	const [version, iv, ciphertext] = parts;
+	const secret = config.keys[version];
+	if (!secret) throw new Error(`Dashboard encryption key ${version} is not configured`);
+
 	const plaintext = await crypto.subtle.decrypt(
-		{ name: 'AES-GCM', iv: decode(iv) },
+		{ name: 'AES-GCM', iv: decode(iv), additionalData: additionalData(ownerKey, version) },
 		await deriveKey(secret),
 		decode(ciphertext)
 	);
-	return new TextDecoder().decode(plaintext);
+	return {
+		plaintext: decoder.decode(plaintext),
+		needsMigration: version !== config.activeVersion
+	};
 }

--- a/src/lib/stores/sync.ts
+++ b/src/lib/stores/sync.ts
@@ -209,6 +209,7 @@ function clearLocalState() {
 	widgets.load();
 	analyticsConnection.reload();
 	cloudflareConnection.reload();
+	cloudflareCredentials.reload();
 }
 
 /**

--- a/src/routes/api/dashboard-state/+server.ts
+++ b/src/routes/api/dashboard-state/+server.ts
@@ -1,7 +1,12 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { env } from '$env/dynamic/private';
-import { decryptState, encryptState } from '$lib/server/stateEncryption';
+import {
+	decryptState,
+	encryptState,
+	parseStateEncryptionConfig,
+	type StateEncryptionConfig
+} from '$lib/server/stateEncryption';
 
 /**
  * Server-side persistence for dashboard state (widgets, sections, layouts,
@@ -20,8 +25,12 @@ interface StoredState {
 // snapshots are a few KB; anything near this is a bug or an abusive client.
 const MAX_STATE_BYTES = 512 * 1024;
 
-function encryptionSecret(): string | null {
-	return env.AUTH_SECRET?.trim() || null;
+function encryptionConfig(): StateEncryptionConfig | null {
+	try {
+		return parseStateEncryptionConfig(env);
+	} catch {
+		return null;
+	}
 }
 
 function getKV(platform: Readonly<App.Platform> | undefined) {
@@ -35,23 +44,52 @@ async function getUserKey(locals: App.Locals): Promise<string | null> {
 	return id ? `dashboard-state:${id}` : null;
 }
 
+function parseStoredState(value: string): StoredState {
+	const stored = JSON.parse(value) as StoredState;
+	if (!stored || typeof stored.state !== 'object' || stored.state === null || typeof stored.updatedAt !== 'number') {
+		throw new Error('Invalid stored dashboard state');
+	}
+	return stored;
+}
+
+async function migrateStoredState(
+	kv: NonNullable<ReturnType<typeof getKV>>,
+	key: string,
+	original: string,
+	stored: StoredState,
+	config: StateEncryptionConfig
+): Promise<void> {
+	try {
+		// KV has no compare-and-set operation. Re-read immediately before the
+		// migration write so a snapshot changed by another request is not replaced
+		// by the older value this GET observed.
+		if (await kv.get(key) !== original) return;
+		await kv.put(key, await encryptState(JSON.stringify(stored), config, key));
+	} catch {
+		// A migration write must not make an otherwise valid snapshot unreadable.
+		// The next GET will retry while the legacy record remains in place.
+	}
+}
+
 export const GET: RequestHandler = async ({ locals, platform }) => {
 	const key = await getUserKey(locals);
 	if (!key) return json({ error: 'Authentication required' }, { status: 401 });
 
 	const kv = getKV(platform);
 	if (!kv) return json({ error: 'Sync not configured' }, { status: 501 });
-	const secret = encryptionSecret();
-	if (!secret) return json({ error: 'Sync encryption not configured' }, { status: 503 });
+	const config = encryptionConfig();
+	if (!config) return json({ error: 'Sync encryption not configured' }, { status: 503 });
 
 	const raw = await kv.get(key);
 	if (!raw) return json({ state: null, updatedAt: 0 });
 
 	try {
-		const stored = JSON.parse(await decryptState(raw, secret)) as StoredState;
+		const decrypted = await decryptState(raw, config, key);
+		const stored = parseStoredState(decrypted.plaintext);
+		if (decrypted.needsMigration) await migrateStoredState(kv, key, raw, stored, config);
 		return json(stored);
 	} catch {
-		return json({ state: null, updatedAt: 0 });
+		return json({ error: 'Synced state could not be decrypted' }, { status: 503 });
 	}
 };
 
@@ -61,8 +99,8 @@ export const PUT: RequestHandler = async ({ locals, platform, request }) => {
 
 	const kv = getKV(platform);
 	if (!kv) return json({ error: 'Sync not configured' }, { status: 501 });
-	const secret = encryptionSecret();
-	if (!secret) return json({ error: 'Sync encryption not configured' }, { status: 503 });
+	const config = encryptionConfig();
+	if (!config) return json({ error: 'Sync encryption not configured' }, { status: 503 });
 
 	let body: StoredState;
 	try {
@@ -84,7 +122,8 @@ export const PUT: RequestHandler = async ({ locals, platform, request }) => {
 	const existingRaw = await kv.get(key);
 	if (existingRaw) {
 		try {
-			const existing = JSON.parse(await decryptState(existingRaw, secret)) as StoredState;
+			const decrypted = await decryptState(existingRaw, config, key);
+			const existing = parseStoredState(decrypted.plaintext);
 			if (existing.updatedAt > body.updatedAt) {
 				return json({ ok: false, conflict: true, updatedAt: existing.updatedAt });
 			}
@@ -93,15 +132,18 @@ export const PUT: RequestHandler = async ({ locals, platform, request }) => {
 			// account-wide). The client guards this too, but each tab tracks its
 			// own last-pushed snapshot, so two open tabs still push the same
 			// bytes twice. See planning/kv-write-amplification.md.
-			if (JSON.stringify(existing.state) === serializedState) {
+			if (!decrypted.needsMigration && JSON.stringify(existing.state) === serializedState) {
 				return json({ ok: true, unchanged: true, updatedAt: existing.updatedAt });
 			}
 		} catch {
-			// corrupt existing state — overwrite it
+			return json(
+				{ error: 'Existing synced state could not be decrypted; refusing to overwrite it' },
+				{ status: 409 }
+			);
 		}
 	}
 
 	const stored = JSON.stringify({ state: body.state, updatedAt: body.updatedAt });
-	await kv.put(key, await encryptState(stored, secret));
+	await kv.put(key, await encryptState(stored, config, key));
 	return json({ ok: true, updatedAt: body.updatedAt });
 };

--- a/src/routes/api/dashboard-state/+server.ts
+++ b/src/routes/api/dashboard-state/+server.ts
@@ -1,5 +1,7 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
+import { env } from '$env/dynamic/private';
+import { decryptState, encryptState } from '$lib/server/stateEncryption';
 
 /**
  * Server-side persistence for dashboard state (widgets, sections, layouts,
@@ -18,6 +20,10 @@ interface StoredState {
 // snapshots are a few KB; anything near this is a bug or an abusive client.
 const MAX_STATE_BYTES = 512 * 1024;
 
+function encryptionSecret(): string | null {
+	return env.AUTH_SECRET?.trim() || null;
+}
+
 function getKV(platform: Readonly<App.Platform> | undefined) {
 	return platform?.env?.DASHBOARD_KV ?? null;
 }
@@ -35,12 +41,14 @@ export const GET: RequestHandler = async ({ locals, platform }) => {
 
 	const kv = getKV(platform);
 	if (!kv) return json({ error: 'Sync not configured' }, { status: 501 });
+	const secret = encryptionSecret();
+	if (!secret) return json({ error: 'Sync encryption not configured' }, { status: 503 });
 
 	const raw = await kv.get(key);
 	if (!raw) return json({ state: null, updatedAt: 0 });
 
 	try {
-		const stored = JSON.parse(raw) as StoredState;
+		const stored = JSON.parse(await decryptState(raw, secret)) as StoredState;
 		return json(stored);
 	} catch {
 		return json({ state: null, updatedAt: 0 });
@@ -53,6 +61,8 @@ export const PUT: RequestHandler = async ({ locals, platform, request }) => {
 
 	const kv = getKV(platform);
 	if (!kv) return json({ error: 'Sync not configured' }, { status: 501 });
+	const secret = encryptionSecret();
+	if (!secret) return json({ error: 'Sync encryption not configured' }, { status: 503 });
 
 	let body: StoredState;
 	try {
@@ -74,7 +84,7 @@ export const PUT: RequestHandler = async ({ locals, platform, request }) => {
 	const existingRaw = await kv.get(key);
 	if (existingRaw) {
 		try {
-			const existing = JSON.parse(existingRaw) as StoredState;
+			const existing = JSON.parse(await decryptState(existingRaw, secret)) as StoredState;
 			if (existing.updatedAt > body.updatedAt) {
 				return json({ ok: false, conflict: true, updatedAt: existing.updatedAt });
 			}
@@ -91,6 +101,7 @@ export const PUT: RequestHandler = async ({ locals, platform, request }) => {
 		}
 	}
 
-	await kv.put(key, JSON.stringify({ state: body.state, updatedAt: body.updatedAt }));
+	const stored = JSON.stringify({ state: body.state, updatedAt: body.updatedAt });
+	await kv.put(key, await encryptState(stored, secret));
 	return json({ ok: true, updatedAt: body.updatedAt });
 };

--- a/src/routes/api/dashboard-state/+server.ts
+++ b/src/routes/api/dashboard-state/+server.ts
@@ -5,6 +5,7 @@ import {
 	decryptState,
 	encryptState,
 	parseStateEncryptionConfig,
+	type DecryptedState,
 	type StateEncryptionConfig
 } from '$lib/server/stateEncryption';
 
@@ -19,6 +20,18 @@ import {
 interface StoredState {
 	state: Record<string, string | null>;
 	updatedAt: number;
+}
+
+interface UserKeys {
+	current: string;
+	migration: string;
+	legacy: string;
+}
+
+interface StoredSource {
+	key: string;
+	stored: StoredState;
+	decrypted: DecryptedState;
 }
 
 // Sanity bound on a dashboard snapshot (KV's own value limit is 25 MB). Real
@@ -37,11 +50,16 @@ function getKV(platform: Readonly<App.Platform> | undefined) {
 	return platform?.env?.DASHBOARD_KV ?? null;
 }
 
-async function getUserKey(locals: App.Locals): Promise<string | null> {
+async function getUserKeys(locals: App.Locals): Promise<UserKeys | null> {
 	const session = await locals.auth();
 	if (!session?.user) return null;
 	const id = session.user.login || session.user.email;
-	return id ? `dashboard-state:${id}` : null;
+	if (!id) return null;
+	return {
+		current: `dashboard-state:v2:${id}`,
+		migration: `dashboard-state:migrated:${id}`,
+		legacy: `dashboard-state:${id}`
+	};
 }
 
 function parseStoredState(value: string): StoredState {
@@ -52,50 +70,75 @@ function parseStoredState(value: string): StoredState {
 	return stored;
 }
 
-async function migrateStoredState(
+async function readStoredState(
 	kv: NonNullable<ReturnType<typeof getKV>>,
-	key: string,
-	original: string,
+	keys: UserKeys,
+	config: StateEncryptionConfig
+): Promise<StoredSource | null> {
+	// Normal writes always use current. A separately keyed migration copy is
+	// authoritative only until the first normal write. The legacy key is last.
+	for (const key of [keys.current, keys.migration, keys.legacy]) {
+		const raw = await kv.get(key);
+		if (!raw) continue;
+		const decrypted = await decryptState(raw, config, key);
+		return { key, stored: parseStoredState(decrypted.plaintext), decrypted };
+	}
+	return null;
+}
+
+async function migrateLegacyState(
+	kv: NonNullable<ReturnType<typeof getKV>>,
+	keys: UserKeys,
 	stored: StoredState,
 	config: StateEncryptionConfig
 ): Promise<void> {
 	try {
-		// KV has no compare-and-set operation. Re-read immediately before the
-		// migration write so a snapshot changed by another request is not replaced
-		// by the older value this GET observed.
-		if (await kv.get(key) !== original) return;
-		await kv.put(key, await encryptState(JSON.stringify(stored), config, key));
+		// The migration has its own destination. A concurrent PUT writes current,
+		// which always wins on reads, so this GET can never overwrite newer state.
+		await kv.put(keys.migration, await encryptState(JSON.stringify(stored), config, keys.migration));
+		await kv.delete(keys.legacy);
 	} catch {
-		// A migration write must not make an otherwise valid snapshot unreadable.
-		// The next GET will retry while the legacy record remains in place.
+		// A failed migration leaves the readable legacy record in place for retry.
+	}
+}
+
+async function deleteIfPresent(
+	kv: NonNullable<ReturnType<typeof getKV>>,
+	key: string
+): Promise<void> {
+	try {
+		await kv.delete(key);
+	} catch {
+		// The canonical current key remains authoritative; cleanup can retry later.
 	}
 }
 
 export const GET: RequestHandler = async ({ locals, platform }) => {
-	const key = await getUserKey(locals);
-	if (!key) return json({ error: 'Authentication required' }, { status: 401 });
+	const keys = await getUserKeys(locals);
+	if (!keys) return json({ error: 'Authentication required' }, { status: 401 });
 
 	const kv = getKV(platform);
 	if (!kv) return json({ error: 'Sync not configured' }, { status: 501 });
 	const config = encryptionConfig();
 	if (!config) return json({ error: 'Sync encryption not configured' }, { status: 503 });
 
-	const raw = await kv.get(key);
-	if (!raw) return json({ state: null, updatedAt: 0 });
-
 	try {
-		const decrypted = await decryptState(raw, config, key);
-		const stored = parseStoredState(decrypted.plaintext);
-		if (decrypted.needsMigration) await migrateStoredState(kv, key, raw, stored, config);
-		return json(stored);
+		const source = await readStoredState(kv, keys, config);
+		if (!source) return json({ state: null, updatedAt: 0 });
+		if (source.key === keys.legacy) {
+			await migrateLegacyState(kv, keys, source.stored, config);
+		} else if (source.key === keys.migration) {
+			await deleteIfPresent(kv, keys.legacy);
+		}
+		return json(source.stored);
 	} catch {
 		return json({ error: 'Synced state could not be decrypted' }, { status: 503 });
 	}
 };
 
 export const PUT: RequestHandler = async ({ locals, platform, request }) => {
-	const key = await getUserKey(locals);
-	if (!key) return json({ error: 'Authentication required' }, { status: 401 });
+	const keys = await getUserKeys(locals);
+	if (!keys) return json({ error: 'Authentication required' }, { status: 401 });
 
 	const kv = getKV(platform);
 	if (!kv) return json({ error: 'Sync not configured' }, { status: 501 });
@@ -118,32 +161,34 @@ export const PUT: RequestHandler = async ({ locals, platform, request }) => {
 		return json({ error: 'State too large' }, { status: 413 });
 	}
 
-	// Don't clobber a newer remote state with an older local one
-	const existingRaw = await kv.get(key);
-	if (existingRaw) {
-		try {
-			const decrypted = await decryptState(existingRaw, config, key);
-			const existing = parseStoredState(decrypted.plaintext);
-			if (existing.updatedAt > body.updatedAt) {
-				return json({ ok: false, conflict: true, updatedAt: existing.updatedAt });
-			}
-			// Byte-identical to what's already stored? Writing it again buys
-			// nothing and KV writes are the scarce free-tier resource (1,000/day
-			// account-wide). The client guards this too, but each tab tracks its
-			// own last-pushed snapshot, so two open tabs still push the same
-			// bytes twice. See planning/kv-write-amplification.md.
-			if (!decrypted.needsMigration && JSON.stringify(existing.state) === serializedState) {
-				return json({ ok: true, unchanged: true, updatedAt: existing.updatedAt });
-			}
-		} catch {
-			return json(
-				{ error: 'Existing synced state could not be decrypted; refusing to overwrite it' },
-				{ status: 409 }
-			);
+	let existing: StoredSource | null;
+	try {
+		existing = await readStoredState(kv, keys, config);
+	} catch {
+		return json(
+			{ error: 'Existing synced state could not be decrypted; refusing to overwrite it' },
+			{ status: 409 }
+		);
+	}
+
+	if (existing) {
+		if (existing.stored.updatedAt > body.updatedAt) {
+			return json({ ok: false, conflict: true, updatedAt: existing.stored.updatedAt });
+		}
+		// Only a current record encrypted by the active key can skip the write.
+		// Legacy/migration records and old key versions are promoted on this PUT.
+		if (
+			existing.key === keys.current &&
+			!existing.decrypted.needsMigration &&
+			JSON.stringify(existing.stored.state) === serializedState
+		) {
+			return json({ ok: true, unchanged: true, updatedAt: existing.stored.updatedAt });
 		}
 	}
 
 	const stored = JSON.stringify({ state: body.state, updatedAt: body.updatedAt });
-	await kv.put(key, await encryptState(stored, config, key));
+	await kv.put(keys.current, await encryptState(stored, config, keys.current));
+	await deleteIfPresent(kv, keys.migration);
+	await deleteIfPresent(kv, keys.legacy);
 	return json({ ok: true, updatedAt: body.updatedAt });
 };

--- a/src/routes/api/dashboard-state/+server.ts
+++ b/src/routes/api/dashboard-state/+server.ts
@@ -30,6 +30,7 @@ interface UserKeys {
 
 interface StoredSource {
 	key: string;
+	raw: string;
 	stored: StoredState;
 	decrypted: DecryptedState;
 }
@@ -37,6 +38,9 @@ interface StoredSource {
 // Sanity bound on a dashboard snapshot (KV's own value limit is 25 MB). Real
 // snapshots are a few KB; anything near this is a bug or an abusive client.
 const MAX_STATE_BYTES = 512 * 1024;
+// Workers KV changes to different keys are not observed atomically. Retain the
+// previous value long enough for the replacement key to propagate globally.
+const FALLBACK_PROPAGATION_TTL_SECONDS = 10 * 60;
 
 function encryptionConfig(): StateEncryptionConfig | null {
 	try {
@@ -81,7 +85,7 @@ async function readStoredState(
 		const raw = await kv.get(key);
 		if (!raw) continue;
 		const decrypted = await decryptState(raw, config, key);
-		return { key, stored: parseStoredState(decrypted.plaintext), decrypted };
+		return { key, raw, stored: parseStoredState(decrypted.plaintext), decrypted };
 	}
 	return null;
 }
@@ -89,6 +93,7 @@ async function readStoredState(
 async function migrateLegacyState(
 	kv: NonNullable<ReturnType<typeof getKV>>,
 	keys: UserKeys,
+	original: string,
 	stored: StoredState,
 	config: StateEncryptionConfig
 ): Promise<void> {
@@ -96,21 +101,18 @@ async function migrateLegacyState(
 		// The migration has its own destination. A concurrent PUT writes current,
 		// which always wins on reads, so this GET can never overwrite newer state.
 		await kv.put(keys.migration, await encryptState(JSON.stringify(stored), config, keys.migration));
-		await kv.delete(keys.legacy);
+		await kv.put(keys.legacy, original, { expirationTtl: FALLBACK_PROPAGATION_TTL_SECONDS });
 	} catch {
 		// A failed migration leaves the readable legacy record in place for retry.
 	}
 }
 
-async function deleteIfPresent(
+async function retainForPropagation(
 	kv: NonNullable<ReturnType<typeof getKV>>,
 	key: string
 ): Promise<void> {
-	try {
-		await kv.delete(key);
-	} catch {
-		// The canonical current key remains authoritative; cleanup can retry later.
-	}
+	const value = await kv.get(key);
+	if (value) await kv.put(key, value, { expirationTtl: FALLBACK_PROPAGATION_TTL_SECONDS });
 }
 
 export const GET: RequestHandler = async ({ locals, platform }) => {
@@ -126,9 +128,7 @@ export const GET: RequestHandler = async ({ locals, platform }) => {
 		const source = await readStoredState(kv, keys, config);
 		if (!source) return json({ state: null, updatedAt: 0 });
 		if (source.key === keys.legacy) {
-			await migrateLegacyState(kv, keys, source.stored, config);
-		} else if (source.key === keys.migration) {
-			await deleteIfPresent(kv, keys.legacy);
+			await migrateLegacyState(kv, keys, source.raw, source.stored, config);
 		}
 		return json(source.stored);
 	} catch {
@@ -188,7 +188,7 @@ export const PUT: RequestHandler = async ({ locals, platform, request }) => {
 
 	const stored = JSON.stringify({ state: body.state, updatedAt: body.updatedAt });
 	await kv.put(keys.current, await encryptState(stored, config, keys.current));
-	await deleteIfPresent(kv, keys.migration);
-	await deleteIfPresent(kv, keys.legacy);
+	await retainForPropagation(kv, keys.migration);
+	await retainForPropagation(kv, keys.legacy);
 	return json({ ok: true, updatedAt: body.updatedAt });
 };

--- a/src/routes/api/dashboard-state/dashboard-state.test.ts
+++ b/src/routes/api/dashboard-state/dashboard-state.test.ts
@@ -17,7 +17,9 @@ function createKV() {
 	return {
 		values,
 		get: vi.fn(async (key: string) => values.get(key) ?? null),
-		put: vi.fn(async (key: string, value: string) => { values.set(key, value); }),
+		put: vi.fn(async (key: string, value: string, _options?: { expirationTtl?: number }) => {
+			values.set(key, value);
+		}),
 		delete: vi.fn(async (key: string) => { values.delete(key); })
 	};
 }
@@ -75,10 +77,11 @@ describe('/api/dashboard-state', () => {
 
 		expect(await response.json()).toEqual({ state: { legacy: 'credential' }, updatedAt: 7 });
 		expect(kv.get).toHaveBeenCalledTimes(3);
-		expect(kv.put).toHaveBeenCalledTimes(1);
-		expect(kv.values.has(legacyAlice)).toBe(false);
+		expect(kv.put).toHaveBeenCalledTimes(2);
+		expect(kv.values.get(legacyAlice)).toBe(legacy);
 		expect(kv.values.get(migrationAlice)).toMatch(/^enc:v2:2026-08:/);
 		expect(kv.values.get(migrationAlice)).not.toContain('credential');
+		expect(kv.put).toHaveBeenLastCalledWith(legacyAlice, legacy, { expirationTtl: 600 });
 	});
 
 	it('cannot overwrite a concurrent PUT while migrating a legacy snapshot', async () => {
@@ -100,6 +103,7 @@ describe('/api/dashboard-state', () => {
 		expect(await nextResponse.json()).toEqual({ state: { value: 'newer' }, updatedAt: 2 });
 		expect(kv.values.get(currentAlice)).toMatch(/^enc:v2:2026-08:/);
 		expect(kv.values.get(migrationAlice)).toMatch(/^enc:v2:2026-08:/);
+		expect(kv.values.get(legacyAlice)).toBe(original);
 	});
 
 	it('still returns valid legacy state when its migration write fails', async () => {

--- a/src/routes/api/dashboard-state/dashboard-state.test.ts
+++ b/src/routes/api/dashboard-state/dashboard-state.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('$env/dynamic/private', () => ({ env: { AUTH_SECRET: 'test-auth-secret' } }));
+
+import { GET, PUT } from './+server';
+
+function createKV() {
+	const values = new Map<string, string>();
+	return {
+		values,
+		get: vi.fn(async (key: string) => values.get(key) ?? null),
+		put: vi.fn(async (key: string, value: string) => { values.set(key, value); }),
+		delete: vi.fn(async (key: string) => { values.delete(key); })
+	};
+}
+
+function event(kv: ReturnType<typeof createKV>, login?: string, request?: Request) {
+	return {
+		locals: { auth: vi.fn(async () => login ? { user: { login } } : null) },
+		platform: { env: { DASHBOARD_KV: kv } },
+		request: request ?? new Request('https://dashboard.test/api/dashboard-state')
+	} as never;
+}
+
+describe('/api/dashboard-state', () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it('rejects unauthenticated reads and writes', async () => {
+		const kv = createKV();
+		const getResponse = await GET(event(kv));
+		const putResponse = await PUT(event(kv, undefined, new Request('https://dashboard.test/api/dashboard-state', {
+			method: 'PUT', body: JSON.stringify({ state: {}, updatedAt: 1 })
+		})));
+
+		expect(getResponse.status).toBe(401);
+		expect(putResponse.status).toBe(401);
+		expect(kv.put).not.toHaveBeenCalled();
+	});
+
+	it('syncs encrypted credentials across devices for only the same user', async () => {
+		const kv = createKV();
+		const state = { 'dashboard-cloudflare-credentials': '{"credentials":[{"token":"cf-secret"}]}' };
+		const putResponse = await PUT(event(kv, 'alice', new Request('https://dashboard.test/api/dashboard-state', {
+			method: 'PUT',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ state, updatedAt: 42 })
+		})));
+		const sameUserResponse = await GET(event(kv, 'alice'));
+		const otherUserResponse = await GET(event(kv, 'bob'));
+
+		expect(putResponse.status).toBe(200);
+		expect(kv.values.get('dashboard-state:alice')).not.toContain('cf-secret');
+		expect(await sameUserResponse.json()).toEqual({ state, updatedAt: 42 });
+		expect(await otherUserResponse.json()).toEqual({ state: null, updatedAt: 0 });
+	});
+
+	it('does not overwrite newer state', async () => {
+		const kv = createKV();
+		await PUT(event(kv, 'alice', new Request('https://dashboard.test/api/dashboard-state', {
+			method: 'PUT', body: JSON.stringify({ state: { value: 'new' }, updatedAt: 10 })
+		})));
+		const response = await PUT(event(kv, 'alice', new Request('https://dashboard.test/api/dashboard-state', {
+			method: 'PUT', body: JSON.stringify({ state: { value: 'old' }, updatedAt: 9 })
+		})));
+
+		expect(await response.json()).toEqual({ ok: false, conflict: true, updatedAt: 10 });
+		expect(kv.put).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/routes/api/dashboard-state/dashboard-state.test.ts
+++ b/src/routes/api/dashboard-state/dashboard-state.test.ts
@@ -32,6 +32,9 @@ function event(kv: ReturnType<typeof createKV>, login?: string, request?: Reques
 
 describe('/api/dashboard-state', () => {
 	beforeEach(() => vi.clearAllMocks());
+	const currentAlice = 'dashboard-state:v2:alice';
+	const migrationAlice = 'dashboard-state:migrated:alice';
+	const legacyAlice = 'dashboard-state:alice';
 
 	it('rejects unauthenticated reads and writes', async () => {
 		const kv = createKV();
@@ -57,53 +60,59 @@ describe('/api/dashboard-state', () => {
 		const otherUserResponse = await GET(event(kv, 'bob'));
 
 		expect(putResponse.status).toBe(200);
-		expect(kv.values.get('dashboard-state:alice')).not.toContain('cf-secret');
+		expect(kv.values.get(currentAlice)).toMatch(/^enc:v2:2026-08:/);
+		expect(kv.values.get(currentAlice)).not.toContain('cf-secret');
 		expect(await sameUserResponse.json()).toEqual({ state, updatedAt: 42 });
 		expect(await otherUserResponse.json()).toEqual({ state: null, updatedAt: 0 });
 	});
 
-	it('re-encrypts a valid plaintext legacy snapshot after a guarded re-read', async () => {
+	it('moves a valid plaintext legacy snapshot to a separate encrypted migration key', async () => {
 		const kv = createKV();
 		const legacy = JSON.stringify({ state: { legacy: 'credential' }, updatedAt: 7 });
-		kv.values.set('dashboard-state:alice', legacy);
+		kv.values.set(legacyAlice, legacy);
 
 		const response = await GET(event(kv, 'alice'));
 
 		expect(await response.json()).toEqual({ state: { legacy: 'credential' }, updatedAt: 7 });
-		expect(kv.get).toHaveBeenCalledTimes(2);
+		expect(kv.get).toHaveBeenCalledTimes(3);
 		expect(kv.put).toHaveBeenCalledTimes(1);
-		expect(kv.values.get('dashboard-state:alice')).toMatch(/^enc:v2:2026-08:/);
-		expect(kv.values.get('dashboard-state:alice')).not.toContain('credential');
+		expect(kv.values.has(legacyAlice)).toBe(false);
+		expect(kv.values.get(migrationAlice)).toMatch(/^enc:v2:2026-08:/);
+		expect(kv.values.get(migrationAlice)).not.toContain('credential');
 	});
 
-	it('does not replace a legacy snapshot that changes during migration', async () => {
+	it('cannot overwrite a concurrent PUT while migrating a legacy snapshot', async () => {
 		const kv = createKV();
 		const original = JSON.stringify({ state: { value: 'original' }, updatedAt: 1 });
-		const newer = JSON.stringify({ state: { value: 'newer' }, updatedAt: 2 });
-		kv.values.set('dashboard-state:alice', original);
-		kv.get.mockImplementationOnce(async () => original).mockImplementationOnce(async () => {
-			kv.values.set('dashboard-state:alice', newer);
-			return newer;
+		kv.values.set(legacyAlice, original);
+		kv.put.mockImplementationOnce(async (key: string, value: string) => {
+			const concurrent = await PUT(event(kv, 'alice', new Request('https://dashboard.test/api/dashboard-state', {
+				method: 'PUT', body: JSON.stringify({ state: { value: 'newer' }, updatedAt: 2 })
+			})));
+			expect(concurrent.status).toBe(200);
+			kv.values.set(key, value);
 		});
 
 		const response = await GET(event(kv, 'alice'));
+		const nextResponse = await GET(event(kv, 'alice'));
 
 		expect(await response.json()).toEqual({ state: { value: 'original' }, updatedAt: 1 });
-		expect(kv.put).not.toHaveBeenCalled();
-		expect(kv.values.get('dashboard-state:alice')).toBe(newer);
+		expect(await nextResponse.json()).toEqual({ state: { value: 'newer' }, updatedAt: 2 });
+		expect(kv.values.get(currentAlice)).toMatch(/^enc:v2:2026-08:/);
+		expect(kv.values.get(migrationAlice)).toMatch(/^enc:v2:2026-08:/);
 	});
 
 	it('still returns valid legacy state when its migration write fails', async () => {
 		const kv = createKV();
 		const legacy = JSON.stringify({ state: { value: 'available' }, updatedAt: 1 });
-		kv.values.set('dashboard-state:alice', legacy);
+		kv.values.set(legacyAlice, legacy);
 		kv.put.mockRejectedValueOnce(new Error('KV write failed'));
 
 		const response = await GET(event(kv, 'alice'));
 
 		expect(response.status).toBe(200);
 		expect(await response.json()).toEqual({ state: { value: 'available' }, updatedAt: 1 });
-		expect(kv.values.get('dashboard-state:alice')).toBe(legacy);
+		expect(kv.values.get(legacyAlice)).toBe(legacy);
 	});
 
 	it('rejects a ciphertext copied under another user key', async () => {
@@ -111,7 +120,7 @@ describe('/api/dashboard-state', () => {
 		await PUT(event(kv, 'alice', new Request('https://dashboard.test/api/dashboard-state', {
 			method: 'PUT', body: JSON.stringify({ state: { token: 'alice-secret' }, updatedAt: 1 })
 		})));
-		kv.values.set('dashboard-state:bob', kv.values.get('dashboard-state:alice')!);
+		kv.values.set('dashboard-state:v2:bob', kv.values.get(currentAlice)!);
 
 		const response = await GET(event(kv, 'bob'));
 
@@ -121,7 +130,7 @@ describe('/api/dashboard-state', () => {
 
 	it('refuses to overwrite an existing snapshot that cannot be decrypted', async () => {
 		const kv = createKV();
-		kv.values.set('dashboard-state:alice', 'enc:v2:missing-key:AA==:AA==');
+		kv.values.set(currentAlice, 'enc:v2:missing-key:AA==:AA==');
 
 		const response = await PUT(event(kv, 'alice', new Request('https://dashboard.test/api/dashboard-state', {
 			method: 'PUT', body: JSON.stringify({ state: { replacement: true }, updatedAt: 2 })
@@ -129,7 +138,7 @@ describe('/api/dashboard-state', () => {
 
 		expect(response.status).toBe(409);
 		expect(kv.put).not.toHaveBeenCalled();
-		expect(kv.values.get('dashboard-state:alice')).toBe('enc:v2:missing-key:AA==:AA==');
+		expect(kv.values.get(currentAlice)).toBe('enc:v2:missing-key:AA==:AA==');
 	});
 
 	it('does not overwrite newer state', async () => {

--- a/src/routes/api/dashboard-state/dashboard-state.test.ts
+++ b/src/routes/api/dashboard-state/dashboard-state.test.ts
@@ -1,6 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('$env/dynamic/private', () => ({ env: { AUTH_SECRET: 'test-auth-secret' } }));
+vi.mock('$env/dynamic/private', () => ({
+	env: {
+		AUTH_SECRET: 'test-auth-secret',
+		DASHBOARD_STATE_ENCRYPTION_KEY_VERSION: '2026-08',
+		DASHBOARD_STATE_ENCRYPTION_KEYS: JSON.stringify({
+			'2026-08': 'test-dashboard-encryption-secret-0001'
+		})
+	}
+}));
 
 import { GET, PUT } from './+server';
 
@@ -52,6 +60,76 @@ describe('/api/dashboard-state', () => {
 		expect(kv.values.get('dashboard-state:alice')).not.toContain('cf-secret');
 		expect(await sameUserResponse.json()).toEqual({ state, updatedAt: 42 });
 		expect(await otherUserResponse.json()).toEqual({ state: null, updatedAt: 0 });
+	});
+
+	it('re-encrypts a valid plaintext legacy snapshot after a guarded re-read', async () => {
+		const kv = createKV();
+		const legacy = JSON.stringify({ state: { legacy: 'credential' }, updatedAt: 7 });
+		kv.values.set('dashboard-state:alice', legacy);
+
+		const response = await GET(event(kv, 'alice'));
+
+		expect(await response.json()).toEqual({ state: { legacy: 'credential' }, updatedAt: 7 });
+		expect(kv.get).toHaveBeenCalledTimes(2);
+		expect(kv.put).toHaveBeenCalledTimes(1);
+		expect(kv.values.get('dashboard-state:alice')).toMatch(/^enc:v2:2026-08:/);
+		expect(kv.values.get('dashboard-state:alice')).not.toContain('credential');
+	});
+
+	it('does not replace a legacy snapshot that changes during migration', async () => {
+		const kv = createKV();
+		const original = JSON.stringify({ state: { value: 'original' }, updatedAt: 1 });
+		const newer = JSON.stringify({ state: { value: 'newer' }, updatedAt: 2 });
+		kv.values.set('dashboard-state:alice', original);
+		kv.get.mockImplementationOnce(async () => original).mockImplementationOnce(async () => {
+			kv.values.set('dashboard-state:alice', newer);
+			return newer;
+		});
+
+		const response = await GET(event(kv, 'alice'));
+
+		expect(await response.json()).toEqual({ state: { value: 'original' }, updatedAt: 1 });
+		expect(kv.put).not.toHaveBeenCalled();
+		expect(kv.values.get('dashboard-state:alice')).toBe(newer);
+	});
+
+	it('still returns valid legacy state when its migration write fails', async () => {
+		const kv = createKV();
+		const legacy = JSON.stringify({ state: { value: 'available' }, updatedAt: 1 });
+		kv.values.set('dashboard-state:alice', legacy);
+		kv.put.mockRejectedValueOnce(new Error('KV write failed'));
+
+		const response = await GET(event(kv, 'alice'));
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({ state: { value: 'available' }, updatedAt: 1 });
+		expect(kv.values.get('dashboard-state:alice')).toBe(legacy);
+	});
+
+	it('rejects a ciphertext copied under another user key', async () => {
+		const kv = createKV();
+		await PUT(event(kv, 'alice', new Request('https://dashboard.test/api/dashboard-state', {
+			method: 'PUT', body: JSON.stringify({ state: { token: 'alice-secret' }, updatedAt: 1 })
+		})));
+		kv.values.set('dashboard-state:bob', kv.values.get('dashboard-state:alice')!);
+
+		const response = await GET(event(kv, 'bob'));
+
+		expect(response.status).toBe(503);
+		expect(await response.json()).toEqual({ error: 'Synced state could not be decrypted' });
+	});
+
+	it('refuses to overwrite an existing snapshot that cannot be decrypted', async () => {
+		const kv = createKV();
+		kv.values.set('dashboard-state:alice', 'enc:v2:missing-key:AA==:AA==');
+
+		const response = await PUT(event(kv, 'alice', new Request('https://dashboard.test/api/dashboard-state', {
+			method: 'PUT', body: JSON.stringify({ state: { replacement: true }, updatedAt: 2 })
+		})));
+
+		expect(response.status).toBe(409);
+		expect(kv.put).not.toHaveBeenCalled();
+		expect(kv.values.get('dashboard-state:alice')).toBe('enc:v2:missing-key:AA==:AA==');
 	});
 
 	it('does not overwrite newer state', async () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
 import { sveltekit } from '@sveltejs/kit/vite';
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	plugins: [sveltekit()],
@@ -7,5 +7,9 @@ export default defineConfig({
 		// Allow the dev Cloudflare tunnel (scripts/dev-tunnel.sh) to reach the
 		// dev server — Vite rejects unknown Host headers with 403 otherwise
 		allowedHosts: ['.starspace.group']
+	},
+	test: {
+		environment: 'node',
+		include: ['src/**/*.{test,spec}.{js,ts}']
 	}
 });


### PR DESCRIPTION
## Summary
- correct local OAuth/browser URLs to port 4200
- encrypt KV-backed dashboard snapshots with user-bound AES-GCM
- move legacy plaintext and AUTH_SECRET ciphertext into a separately keyed encrypted migration record on read
- retain fallback KV values for a bounded propagation window before automatic expiry
- use a dedicated, versioned, own-property-checked encryption keyring that survives AUTH_SECRET rotation
- promote migration records and old key versions to the active canonical key on normal writes
- fail closed instead of overwriting snapshots that cannot be decrypted
- clear in-memory Cloudflare credentials when accounts switch
- run the encryption and sync regression suite in CI

## Verification
- npm run lint
- npm run check (0 errors, 0 warnings)
- npm test (17 tests passed)
- npm run build

## Deployment
- Set DASHBOARD_STATE_ENCRYPTION_KEY_VERSION to the active version, for example v1.
- Set DASHBOARD_STATE_ENCRYPTION_KEYS to a JSON object containing independently generated secrets for the active and retained old versions.
- Deploy once with the existing AUTH_SECRET so enc:v1 snapshots can migrate.
- Retain old encryption-key versions until old records are next written or deliberately migrated.
- If AUTH_SECRET must rotate before migration is complete, set DASHBOARD_STATE_LEGACY_AUTH_SECRETS to a JSON array containing the previous AUTH_SECRET until all legacy records have migrated.