### PR TITLE
fix: sort GitHub Projects by most recently updated (closes #3)

### DIFF
--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -411,6 +411,20 @@ export const load: PageServerLoad = async ({ locals, fetch, platform }) => {
 					}
 				}
 
+				// Each projectsV2 connection is ordered UPDATED_AT DESC on its own, but the
+				// personal list and every org list are concatenated above, so the merged
+				// array is grouped by owner rather than sorted. Re-sort the whole set so the
+				// widget shows the most recently updated project first, regardless of owner.
+				projects.sort((a, b) => {
+					const aTime = Date.parse(a.updatedAt);
+					const bTime = Date.parse(b.updatedAt);
+					// Missing/unparseable timestamps sort last instead of poisoning the order.
+					if (Number.isNaN(aTime) && Number.isNaN(bTime)) return 0;
+					if (Number.isNaN(aTime)) return 1;
+					if (Number.isNaN(bTime)) return -1;
+					return bTime - aTime;
+				});
+
 				return projects;
 			} catch (error) {
 				console.error('[ERROR] Failed to fetch GitHub Projects:', error);


### PR DESCRIPTION
Closes #3

## The defect

`fetchGraphQLProjects()` in `src/routes/+page.server.ts` requests each ProjectsV2 connection with `orderBy: {field: UPDATED_AT, direction: DESC}` — the viewer's personal projects, and separately each organization's projects. Each *connection* therefore arrives sorted.

But the results are then appended to one array in owner order: personal projects first, then org #1's projects, then org #2's, and so on. The merged array that reaches `GithubProjectsWidget` (via `data.allGithubProjects`) is grouped by owner, **not** sorted by update time. An org project touched an hour ago renders below a personal project last touched months ago.

## The change

One `sort` on the merged array before returning, in `fetchGraphQLProjects()`:

- Sorts by `updatedAt` descending, so the most recently updated project is first regardless of owner.
- Entries whose `updatedAt` fails `Date.parse` sort last rather than returning `NaN` from the comparator and corrupting the order.

No GraphQL query change; the per-connection `orderBy` is retained so the `first: 20` page still picks the 20 most recent per owner.

## Gate

There is no test runner and no CI workflow in this repo, so the gate is the three scripts in `package.json`. All three run on this branch:

```
$ npm run lint
> eslint .
LINT EXIT: 0

$ npm run check
> svelte-kit sync && svelte-check --tsconfig ./tsconfig.json
svelte-check found 0 errors and 0 warnings
CHECK EXIT: 0

$ npm run build
> vite build
✓ built in 12.4s
> Using @sveltejs/adapter-cloudflare
  ✔ done
BUILD EXIT: 0
```

Baseline on `main` at `7a82cc6` was also green on all three, so this branch introduces no regression against it.

**No automated check ran on this PR.** `gh pr checks 25` reports `no checks reported on the 'fix/issue-3-sort-github-projects-by-updated' branch` — the repo has no `.github/workflows`, and the Cloudflare Pages check that runs on same-repo PRs (e.g. #18) does not fire for fork branches. The gate output above is from my machine only.

## What I did NOT verify

- **No runtime or visual verification.** The repo has no test runner, so nothing here was executed against real GitHub data or rendered in a browser. The claim that the order is wrong today is read off the source, and the fix is verified only as "type-checks, lints, and builds".
- I did not sign in, so I never observed the actual ProjectsV2 payload — in particular I did not confirm empirically that `updatedAt` is always a parseable ISO-8601 string (the `NaN` guard exists because I could not).
- The GitHub payload is cached in KV per user for 3 minutes (fresh) / 24 h (stale). **Existing cached entries keep the old order until they expire** — I did not add or bump a cache key, so a user may see the previous ordering for up to 24 h if the stale path is hit.
- `npm ci` here reported `install-scripts not yet covered by allowScripts` for esbuild/workerd/sharp, so the local build ran without those postinstall steps and is not byte-identical to the Cloudflare Pages build environment.

## Notes

- Untested against PR #18 (Spotify widget), which also touches `src/routes/+page.server.ts` and is currently in a conflicting state against `main`.
- Opened from a fork: this account has read-only access to `starspacegroup/dashboard` and cannot merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
