### PR TITLE
fix: F/C toggle switches from either half (addresses #8)

### DIFF
--- a/src/lib/components/SettingsModal.svelte
+++ b/src/lib/components/SettingsModal.svelte
@@ -150,6 +150,13 @@
 		}
 	}
 
+	// The °F/°C control is a two-state switch, so a click anywhere on it means
+	// "give me the other option" — including a click on the half that is already
+	// active, which previously re-selected the current unit and did nothing.
+	function toggleTemperatureUnit() {
+		saveTemperatureUnit(globalTemperatureUnit === 'fahrenheit' ? 'celsius' : 'fahrenheit');
+	}
+
 	// Handle modal backdrop click
 	function handleBackdropClick(event: MouseEvent) {
 		if (event.target === event.currentTarget) {
@@ -345,17 +352,21 @@
 					</p>
 
 					<div class="temperature-unit-selector">
-						<button 
-							class="unit-button" 
+						<button
+							class="unit-button"
 							class:active={globalTemperatureUnit === 'fahrenheit'}
-							on:click={() => saveTemperatureUnit('fahrenheit')}
+							aria-pressed={globalTemperatureUnit === 'fahrenheit'}
+							title="Switch to {globalTemperatureUnit === 'fahrenheit' ? 'Celsius (°C)' : 'Fahrenheit (°F)'}"
+							on:click={toggleTemperatureUnit}
 						>
 							°F
 						</button>
-						<button 
-							class="unit-button" 
+						<button
+							class="unit-button"
 							class:active={globalTemperatureUnit === 'celsius'}
-							on:click={() => saveTemperatureUnit('celsius')}
+							aria-pressed={globalTemperatureUnit === 'celsius'}
+							title="Switch to {globalTemperatureUnit === 'fahrenheit' ? 'Celsius (°C)' : 'Fahrenheit (°F)'}"
+							on:click={toggleTemperatureUnit}
 						>
 							°C
 						</button>


### PR DESCRIPTION
Addresses #8 (deliberately not `Closes` — see "Scope" below; one case in the issue's wording is left unfixed)

## The defect

The global **Temperature Unit** control in `SettingsModal.svelte` is a two-option °F / °C switch, but each half was wired to set an absolute value:

```svelte
on:click={() => saveTemperatureUnit('fahrenheit')}
on:click={() => saveTemperatureUnit('celsius')}
```

So the switch only responded when you happened to click the *inactive* half. Clicking the half that was already selected re-saved the current unit — no visible change, but it still wrote localStorage and dispatched `temperature-unit-changed` + `dashboard-state-changed`. From the user's side, whether the switch works depends on where on it you click, which is exactly what the issue reports.

## The change

- Added `toggleTemperatureUnit()`, which flips to the other unit and routes through the existing `saveTemperatureUnit()` (so the localStorage write, the `temperature-unit-changed` event, and the `dashboard-state-changed` sync event all still fire exactly as before).
- Both halves now call it, so a click anywhere on the switch toggles.
- Added `aria-pressed` to each half, and a `title` naming the unit the click will switch to.

No change to the store, the event contract, or the persisted value shape.

## Scope — three things deliberately left alone

**1. The gap between the two halves is still a dead click target.** The issue says "no matter where you click on the toggle switch". `.temperature-unit-selector` is `display: flex; gap: 0.75rem`, so there is 0.75rem of bare container between the buttons. A click that lands there does nothing — before this PR and after it. Closing that gap means restyling the control as one continuous surface, which is a visual change I can't verify with this repo's gate, so I left it and am not claiming the issue is fully closed.

**2. The control still *looks* like a two-option selector.** Two labeled buttons with one highlighted reads as "click °C to pick °C" — but after this change, clicking °C while °C is active gives you °F. That's what the issue asks for, and it's the right behavior for a switch; it just means the affordance now argues with the behavior. If the intent is a real switch (single track, sliding thumb) rather than a segmented selector, that's a design call worth making explicitly — happy to follow up once decided.

**3. `WeatherWidgetSettings.svelte` is untouched.** It has a *three*-option per-widget selector (**Use Global** / °F / °C), not a two-state switch. "Toggle to the other option" has no single obvious meaning across three states — particularly when *Use Global* is active. If the issue was meant to cover that control too, say so and I'll follow up.

## Gate

There is no test runner and no CI workflow in this repo, so the gate is the three scripts in `package.json`. All three run on this branch:

```
$ npm run lint
> eslint .
LINT EXIT: 0

$ npm run check
> svelte-kit sync && svelte-check --tsconfig ./tsconfig.json
svelte-check found 0 errors and 0 warnings
CHECK EXIT: 0

$ npm run build
> vite build
> Using @sveltejs/adapter-cloudflare
  ✔ done
BUILD EXIT: 0
```

Baseline on `main` at `7a82cc6` was also green on all three, so this branch introduces no regression against it.

**No automated check ran on this PR.** `gh pr checks 26` reports `no checks reported on the 'fix/issue-8-fc-toggle' branch` — the repo has no `.github/workflows`, and the Cloudflare Pages check that runs on same-repo PRs (e.g. #18) does not fire for fork branches. The gate output above is from my machine only.

## What I did NOT verify

- **No runtime or visual verification.** This is a click-behavior change and the repo has no test runner, so nothing here was clicked in a browser. A green gate means "type-checks, lints, and builds" — it is not evidence the toggle behaves correctly on screen. Someone should click both halves once before merging.
- I did not verify that weather widgets actually re-render on the resulting `temperature-unit-changed` event; that path is unchanged by this PR but also unexercised by it.
- I did not check how this interacts with the cross-device sync push in `src/lib/stores/sync.ts`. Note one behavioral side effect: clicking the already-active half used to fire a redundant `dashboard-state-changed`, and now fires a real state change instead — fewer no-op events, but each click is now a genuine change.
- `npm ci` here reported `install-scripts not yet covered by allowScripts` for esbuild/workerd/sharp, so the local build ran without those postinstall steps and is not byte-identical to the Cloudflare Pages build environment.

## Notes

- Opened from a fork: this account has read-only access to `starspacegroup/dashboard` and cannot merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
